### PR TITLE
drawing rects now compatible with canvas2svg 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -152,7 +152,7 @@ rules:
   max-nested-callbacks: 0
   max-params: 0
   max-statements-per-line: 0
-  max-statements: [2, 40]
+  max-statements: [2, 43]
   multiline-ternary: 0
   new-cap: 0
   new-parens: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-chart-box-and-violin-plot",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4107,12 +4107,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4127,17 +4129,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4254,7 +4259,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4266,6 +4272,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4280,6 +4287,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4287,12 +4295,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4311,6 +4321,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4391,7 +4402,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4403,6 +4415,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4524,6 +4537,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chartjs-chart-box-and-violin-plot",
   "description": "Chart.js module for charting boxplots",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "name": "Samuel Gratzl",
     "email": "samuel.gratzl@datavisyn.io",

--- a/src/elements/boxandwhiskers.js
+++ b/src/elements/boxandwhiskers.js
@@ -74,13 +74,18 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
 
   },
   _drawBoxPlot(vm, boxplot, ctx, vert) {
-    ctx.beginPath();
     if (vert) {
       const x = vm.x;
       const width = vm.width;
       const x0 = x - width / 2;
-      ctx.fillRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
-      ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+      if (boxplot.q3 > boxplot.q1) {
+        ctx.fillRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+        ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+      } else {
+        ctx.fillRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
+        ctx.strokeRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
+      }
+      ctx.beginPath();
       ctx.moveTo(x0, boxplot.whiskerMin);
       ctx.lineTo(x0 + width, boxplot.whiskerMin);
       ctx.moveTo(x, boxplot.whiskerMin);
@@ -91,13 +96,20 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
       ctx.lineTo(x, boxplot.q3);
       ctx.moveTo(x0, boxplot.median);
       ctx.lineTo(x0 + width, boxplot.median);
+      ctx.closePath();
+      ctx.stroke();
     } else {
       const y = vm.y;
       const height = vm.height;
       const y0 = y - height / 2;
-      ctx.fillRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
-      ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
-
+      if (boxplot.q3 > boxplot.q1) {
+        ctx.fillRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
+        ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
+      } else {
+        ctx.fillRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
+        ctx.strokeRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
+      }
+      ctx.beginPath();
       ctx.moveTo(boxplot.whiskerMin, y0);
       ctx.lineTo(boxplot.whiskerMin, y0 + height);
       ctx.moveTo(boxplot.whiskerMin, y);
@@ -108,9 +120,10 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
       ctx.lineTo(boxplot.q3, y);
       ctx.moveTo(boxplot.median, y0);
       ctx.lineTo(boxplot.median, y0 + height);
+      ctx.closePath();
+      ctx.stroke();
     }
-    ctx.stroke();
-    ctx.closePath();
+
   },
   _getBounds() {
     const vm = this._view;


### PR DESCRIPTION
While a niche issue, others might benefit from this as well. 

I encountered an issue when combining chart.js + this plugin with canvas2svg.js ( https://github.com/gliffy/canvas2svg ). The rectangles making up the boxplot were drawn with a negative height, canvas2svg was unable to deal with that. 

This PR provides a solution for this.

Kind regards,
Sebastian
