### PR TITLE
Ability to configure a color for the median line

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ interface IBaseStyling {
    */
   strokeColor: string;
   /**
+     * @default see rectangle
+     */
+  medianColor: string;
+  /**
    * @default 1
    */
   borderWidth: number;

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ interface IBaseStyling {
    */
   strokeColor: string;
   /**
-     * @default see rectangle
+     * @default null takes the current strokeColor
      */
   medianColor: string;
   /**

--- a/src/controllers/base.js
+++ b/src/controllers/base.js
@@ -27,7 +27,7 @@ const array = {
     const options = this._elementOptions();
 
     Chart.controllers.bar.prototype.updateElement.call(this, elem, index, reset);
-    ['outlierRadius', 'itemRadius', 'itemStyle', 'itemBackgroundColor', 'itemBorderColor', 'outlierColor', 'hitPadding'].forEach((item) => {
+    ['outlierRadius', 'itemRadius', 'itemStyle', 'itemBackgroundColor', 'itemBorderColor', 'outlierColor', 'medianColor', 'hitPadding'].forEach((item) => {
       elem._model[item] = custom[item] !== undefined ? custom[item] : Chart.helpers.valueAtIndexOrDefault(dataset[item], index, options[item]);
     });
   },

--- a/src/elements/base.js
+++ b/src/elements/base.js
@@ -8,6 +8,7 @@ export const defaults = {
   borderWidth: 1,
   outlierRadius: 2,
   outlierColor: Chart.defaults.global.elements.rectangle.backgroundColor,
+  medianColor: Chart.defaults.global.elements.rectangle.borderColor,
   itemRadius: 0,
   itemStyle: 'circle',
   itemBackgroundColor: Chart.defaults.global.elements.rectangle.backgroundColor,

--- a/src/elements/base.js
+++ b/src/elements/base.js
@@ -8,7 +8,7 @@ export const defaults = {
   borderWidth: 1,
   outlierRadius: 2,
   outlierColor: Chart.defaults.global.elements.rectangle.backgroundColor,
-  medianColor: Chart.defaults.global.elements.rectangle.borderColor,
+  medianColor: null,
   itemRadius: 0,
   itemStyle: 'circle',
   itemBackgroundColor: Chart.defaults.global.elements.rectangle.backgroundColor,

--- a/src/elements/boxandwhiskers.js
+++ b/src/elements/boxandwhiskers.js
@@ -75,55 +75,69 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
   },
   _drawBoxPlot(vm, boxplot, ctx, vert) {
     if (vert) {
-      const x = vm.x;
-      const width = vm.width;
-      const x0 = x - width / 2;
-      if (boxplot.q3 > boxplot.q1) {
-        ctx.fillRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
-        ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
-      } else {
-        ctx.fillRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
-        ctx.strokeRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
-      }
-      ctx.beginPath();
-      ctx.moveTo(x0, boxplot.whiskerMin);
-      ctx.lineTo(x0 + width, boxplot.whiskerMin);
-      ctx.moveTo(x, boxplot.whiskerMin);
-      ctx.lineTo(x, boxplot.q1);
-      ctx.moveTo(x0, boxplot.whiskerMax);
-      ctx.lineTo(x0 + width, boxplot.whiskerMax);
-      ctx.moveTo(x, boxplot.whiskerMax);
-      ctx.lineTo(x, boxplot.q3);
-      ctx.moveTo(x0, boxplot.median);
-      ctx.lineTo(x0 + width, boxplot.median);
-      ctx.closePath();
-      ctx.stroke();
+      this._drawBoxPlotVert(vm, boxplot, ctx);
     } else {
-      const y = vm.y;
-      const height = vm.height;
-      const y0 = y - height / 2;
-      if (boxplot.q3 > boxplot.q1) {
-        ctx.fillRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
-        ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
-      } else {
-        ctx.fillRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
-        ctx.strokeRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
-      }
-      ctx.beginPath();
-      ctx.moveTo(boxplot.whiskerMin, y0);
-      ctx.lineTo(boxplot.whiskerMin, y0 + height);
-      ctx.moveTo(boxplot.whiskerMin, y);
-      ctx.lineTo(boxplot.q1, y);
-      ctx.moveTo(boxplot.whiskerMax, y0);
-      ctx.lineTo(boxplot.whiskerMax, y0 + height);
-      ctx.moveTo(boxplot.whiskerMax, y);
-      ctx.lineTo(boxplot.q3, y);
-      ctx.moveTo(boxplot.median, y0);
-      ctx.lineTo(boxplot.median, y0 + height);
-      ctx.closePath();
-      ctx.stroke();
+      this._drawBoxPlotHoriz(vm, boxplot, ctx);
     }
 
+  },
+  _drawBoxPlotVert(vm, boxplot, ctx) {
+    const x = vm.x;
+    const width = vm.width;
+    const x0 = x - width / 2;
+    if (boxplot.q3 > boxplot.q1) {
+      ctx.fillRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+      ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+    } else {
+      ctx.fillRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
+      ctx.strokeRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
+    }
+    ctx.beginPath();
+    ctx.moveTo(x0, boxplot.whiskerMin);
+    ctx.lineTo(x0 + width, boxplot.whiskerMin);
+    ctx.moveTo(x, boxplot.whiskerMin);
+    ctx.lineTo(x, boxplot.q1);
+    ctx.moveTo(x0, boxplot.whiskerMax);
+    ctx.lineTo(x0 + width, boxplot.whiskerMax);
+    ctx.moveTo(x, boxplot.whiskerMax);
+    ctx.lineTo(x, boxplot.q3);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.strokeStyle = vm.medianColor;
+    ctx.beginPath();
+    ctx.moveTo(x0, boxplot.median);
+    ctx.lineTo(x0 + width, boxplot.median);
+    ctx.closePath();
+    ctx.stroke();
+  },
+  _drawBoxPlotHoriz(vm, boxplot, ctx) {
+    const y = vm.y;
+    const height = vm.height;
+    const y0 = y - height / 2;
+    if (boxplot.q3 > boxplot.q1) {
+      ctx.fillRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
+      ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
+    } else {
+      ctx.fillRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
+      ctx.strokeRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
+    }
+    ctx.beginPath();
+    ctx.moveTo(boxplot.whiskerMin, y0);
+    ctx.lineTo(boxplot.whiskerMin, y0 + height);
+    ctx.moveTo(boxplot.whiskerMin, y);
+    ctx.lineTo(boxplot.q1, y);
+    ctx.moveTo(boxplot.whiskerMax, y0);
+    ctx.lineTo(boxplot.whiskerMax, y0 + height);
+    ctx.moveTo(boxplot.whiskerMax, y);
+    ctx.lineTo(boxplot.q3, y);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.strokeStyle = vm.medianColor;
+    ctx.beginPath();
+    ctx.moveTo(boxplot.median, y0);
+    ctx.lineTo(boxplot.median, y0 + height);
+    ctx.closePath();
+    ctx.stroke();
   },
   _getBounds() {
     const vm = this._view;

--- a/src/elements/boxandwhiskers.js
+++ b/src/elements/boxandwhiskers.js
@@ -103,12 +103,14 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
     ctx.lineTo(x, boxplot.q3);
     ctx.closePath();
     ctx.stroke();
+    ctx.save();
     ctx.strokeStyle = vm.medianColor;
     ctx.beginPath();
     ctx.moveTo(x0, boxplot.median);
     ctx.lineTo(x0 + width, boxplot.median);
     ctx.closePath();
     ctx.stroke();
+    ctx.restore();
   },
   _drawBoxPlotHoriz(vm, boxplot, ctx) {
     const y = vm.y;

--- a/src/elements/boxandwhiskers.js
+++ b/src/elements/boxandwhiskers.js
@@ -85,13 +85,34 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
     const x = vm.x;
     const width = vm.width;
     const x0 = x - width / 2;
+
+    // Draw the q1>q3 box
     if (boxplot.q3 > boxplot.q1) {
       ctx.fillRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
-      ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
     } else {
       ctx.fillRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
+    }
+
+    // Draw the median line
+    ctx.save();
+    if (vm.medianColor) {
+      ctx.strokeStyle = vm.medianColor;
+    }
+    ctx.beginPath();
+    ctx.moveTo(x0, boxplot.median);
+    ctx.lineTo(x0 + width, boxplot.median);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+
+    // Draw the border around the main q1>q3 box
+    if (boxplot.q3 > boxplot.q1) {
+      ctx.strokeRect(x0, boxplot.q1, width, boxplot.q3 - boxplot.q1);
+    } else {
       ctx.strokeRect(x0, boxplot.q3, width, boxplot.q1 - boxplot.q3);
     }
+
+    // Draw the whiskers
     ctx.beginPath();
     ctx.moveTo(x0, boxplot.whiskerMin);
     ctx.lineTo(x0 + width, boxplot.whiskerMin);
@@ -103,26 +124,39 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
     ctx.lineTo(x, boxplot.q3);
     ctx.closePath();
     ctx.stroke();
-    ctx.save();
-    ctx.strokeStyle = vm.medianColor;
-    ctx.beginPath();
-    ctx.moveTo(x0, boxplot.median);
-    ctx.lineTo(x0 + width, boxplot.median);
-    ctx.closePath();
-    ctx.stroke();
-    ctx.restore();
   },
   _drawBoxPlotHoriz(vm, boxplot, ctx) {
     const y = vm.y;
     const height = vm.height;
     const y0 = y - height / 2;
+
+    // Draw the q1>q3 box
     if (boxplot.q3 > boxplot.q1) {
       ctx.fillRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
-      ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
     } else {
       ctx.fillRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
+    }
+
+    // Draw the median line
+    ctx.save();
+    if (vm.medianColor) {
+      ctx.strokeStyle = vm.medianColor;
+    }
+    ctx.beginPath();
+    ctx.moveTo(boxplot.median, y0);
+    ctx.lineTo(boxplot.median, y0 + height);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+
+    // Draw the border around the main q1>q3 box
+    if (boxplot.q3 > boxplot.q1) {
+      ctx.strokeRect(boxplot.q1, y0, boxplot.q3 - boxplot.q1, height);
+    } else {
       ctx.strokeRect(boxplot.q3, y0, boxplot.q1 - boxplot.q3, height);
     }
+
+    // Draw the whiskers
     ctx.beginPath();
     ctx.moveTo(boxplot.whiskerMin, y0);
     ctx.lineTo(boxplot.whiskerMin, y0 + height);
@@ -132,12 +166,6 @@ const BoxAndWiskers = Chart.elements.BoxAndWhiskers = ArrayElementBase.extend({
     ctx.lineTo(boxplot.whiskerMax, y0 + height);
     ctx.moveTo(boxplot.whiskerMax, y);
     ctx.lineTo(boxplot.q3, y);
-    ctx.closePath();
-    ctx.stroke();
-    ctx.strokeStyle = vm.medianColor;
-    ctx.beginPath();
-    ctx.moveTo(boxplot.median, y0);
-    ctx.lineTo(boxplot.median, y0 + height);
     ctx.closePath();
     ctx.stroke();
   },


### PR DESCRIPTION
Adds a `medianColor` style property which allows a median line to be highlighted if the whiskers and background are similar, or hard to distinguish colours:

![screenshot 2019-02-16 at 14 28 24](https://user-images.githubusercontent.com/981125/52901166-6ef8e800-31f7-11e9-9ee4-6f29c1807d6d.png)

```
const chartData = {
    ...
    datasets: [{
        label: 'Dataset 1',
        backgroundColor: 'blue',
        medianColor: 'white',
        borderColor: 'blue',
        ...
    }]
}
```